### PR TITLE
Merge ExtractionViewModel from dev_20200404 branch.

### DIFF
--- a/src/7zip.sln
+++ b/src/7zip.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.8.34112.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DA082B34-ABE7-400D-AE6C-1F3C27A63C83}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "7zip", "7zip\7zip.csproj", "{09908D9F-6FB7-459A-B4A6-AF1853132979}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "7zip", "7zip\7Zip.App.csproj", "{09908D9F-6FB7-459A-B4A6-AF1853132979}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A1F7BD86-3822-4F3C-BB06-2783E9983833}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
there is a newer version of ExtractionViewModel.cs in dev_20200404 branch. It provides newly added temp output functionalities.

The structure of the solution had changed significantly, so just move ExtractionViewModel.cs to the LightningBasedonDevelop branch.